### PR TITLE
Feature/display server name on level up

### DIFF
--- a/src/functions/exp/main.py
+++ b/src/functions/exp/main.py
@@ -32,8 +32,9 @@ def exp(request: flask.Request) -> Tuple[None, int]:
         username = request_json.get("username", None)
         avatar_url = request_json.get("avatar_url", None)
         server_id = request_json.get("server_id", None)
+        server_name = request_json.get("server_name", None)
 
-        if not user_id or not username or not server_id:
+        if not user_id or not username or not server_id or not server_name:
             print("Exit: Missing data in payload")
             return "", 200
 
@@ -69,12 +70,14 @@ def exp(request: flask.Request) -> Tuple[None, int]:
             batch.update(doc_ref, ({"message_count": Increment(1)}))
 
             if added_exp >= exp_needed_to_level_up:
-                print(f"Update: level up user {user_id} to level {level+1}")
+                print(f"Update: level up user {user_id} to level {level+1} in {server_name}")
 
                 batch.update(doc_ref, ({"level": Increment(1)}))
                 batch.update(doc_ref, ({"exp_toward_next_level": added_exp - exp_needed_to_level_up}))
 
-                send_message_to_user(user_id, f"I'm so proud of you... You made it to level {level+1}!")
+                send_message_to_user(
+                    user_id, f"I'm so proud of you... You made it to level {level+1} in {server_name}!"
+                )
 
             else:
                 print(f"Update: Increase {user_id}'s exp")

--- a/src/main.py
+++ b/src/main.py
@@ -43,6 +43,7 @@ async def on_message(message: message_type) -> None:
             data=json.dumps(
                 {
                     "server_id": str(ctx.guild.id),
+                    "server_name": str(ctx.message.guild.name),
                     "user_id": str(ctx.author.id),
                     "username": str(ctx.author.name),
                     "channel_id": str(message.channel.id),
@@ -78,6 +79,7 @@ async def on_message(message: message_type) -> None:
                 {
                     "server_id": str(ctx.guild.id),
                     "user_id": str(ctx.author.id),
+                    "server_name": str(ctx.message.guild.name),
                     "username": str(ctx.author.name),
                     "avatar_url": f"{ctx.author.avatar_url.BASE}{ctx.author.avatar_url._url}",  # pylint: disable=W0212
                 }

--- a/src/tests/functions/exp/test_exp.py
+++ b/src/tests/functions/exp/test_exp.py
@@ -83,7 +83,7 @@ def test_exp_missing_data(random_mock, database_mock, body):
 @patch(f"{MODULE_PATH}.Client")
 @patch("random.randint")
 def test_exp_level_up(random_mock, database_mock):
-    body = {"user_id": "123", "username": "Joe", "avatar_url": "url", "server_id": 123456789}
+    body = {"user_id": "123", "username": "Joe", "avatar_url": "url", "server_id": 123456789, "server_name": "Archy"}
 
     request_mock = MagicMock()
     request_mock.get_json.return_value = body
@@ -103,7 +103,7 @@ def test_exp_level_up(random_mock, database_mock):
 
 @patch(f"{MODULE_PATH}.Client")
 def test_exp_new_user(database_mock):
-    body = {"user_id": "123", "username": "Joe", "avatar_url": "url", "server_id": 123456789}
+    body = {"user_id": "123", "username": "Joe", "avatar_url": "url", "server_id": 123456789, "server_name": "Archy"}
     expected_set_value = {
         "total_exp": 0,
         "exp_toward_next_level": 0,


### PR DESCRIPTION
This is related to issue #14 

Feature:
- Archy will display the server name following his congratulation's message for the level up.

Fix:
- Add server_name variable in the body for the src/test/functions/test_exp.py, src/main.py and src/functions/exp/main.py
- Add the server_name in the print in src/functions/exp/main.py
- Formatted with black because of the change brought 
- All test passed with tox