### PR TITLE
Feature/add multiword parameters for functions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import re
+import shlex
 from datetime import datetime
 
 import firebase_admin
@@ -183,7 +184,7 @@ async def on_message(message: message_type) -> None:
                     "channel_id": str(message.channel.id),
                     "message_id": str(message.id),
                     "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-                    "params": message.content.split(ctx.command)[1:],
+                    "params": shlex.split(message.content)[1:],
                 }
             ),
         )


### PR DESCRIPTION
For #65 

Change the way parameters are split to allow for multiword parameters using the `shlex` library.