### PR TITLE
Python type enforcement

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -40,6 +40,7 @@ Simply run the `tox` command to execute all the test script in the `tox.ini` fil
 - `black` -> Code formatter.
 - `pylint` -> Static code analysis tool for lint.
 - `isort` -> isort your imports, so you don't have to.
+- `mypy` -> Python typing check utility.
 
 You can run the script by hand if you want:
 
@@ -48,6 +49,7 @@ python -m pytest --rootdir .
 black -l 120 .
 pylint functions tests main.py
 isort .
+mypy --install-types --non-interactive --show-error-codes functions/ main.py
 ```
 
 ## Requirements

--- a/src/functions/answer/main.py
+++ b/src/functions/answer/main.py
@@ -1,6 +1,7 @@
 import random
 from typing import Tuple
 
+import flask
 import functions_framework
 
 POSSIBLE_ANSWERS = [
@@ -28,7 +29,7 @@ POSSIBLE_ANSWERS = [
 
 
 @functions_framework.http
-def answer(_request) -> Tuple[str, int]:
+def answer(_request: flask.Request) -> Tuple[str, int]:
     """This is a function that returns a random answer from a predefined list based on 8ball."""
 
     return random.choice(POSSIBLE_ANSWERS), 200

--- a/src/functions/describe/main.py
+++ b/src/functions/describe/main.py
@@ -1,10 +1,11 @@
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
+import flask
 import functions_framework
 
 
 @functions_framework.http
-def describe(request):
+def describe(request: flask.Request) -> Tuple[str, int]:
     """Describe the user in mentions or the author."""
 
     request_json: Optional[Any] = request.get_json(silent=True)

--- a/src/functions/exp/main.py
+++ b/src/functions/exp/main.py
@@ -2,6 +2,7 @@ import base64
 import json
 import random
 from datetime import datetime
+from typing import Tuple
 
 from google.cloud.firestore import Increment
 from google.cloud.firestore_v1.base_document import DocumentSnapshot
@@ -17,7 +18,7 @@ DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 TMP_FILE_PATH = "/tmp/tmp.json"
 
 
-def exp(event: dict, _context: Context):
+def exp(event: dict, _context: Context) -> Tuple[str, int]:
     """Increase the user experience on firestore."""
 
     pubsub_message = json.loads(base64.b64decode(event["data"]).decode("utf-8"))
@@ -73,10 +74,14 @@ def exp(event: dict, _context: Context):
                 print(f"Update: level up user {user_id} to level {level+1} in {server_name}")
 
                 batch.update(doc_ref, ({"level": Increment(1)}))
-                batch.update(doc_ref, ({"exp_toward_next_level": added_exp - exp_needed_to_level_up}))
+                batch.update(
+                    doc_ref,
+                    ({"exp_toward_next_level": added_exp - exp_needed_to_level_up}),
+                )
 
                 send_message_to_user(
-                    user_id, f"I'm so proud of you... You made it to level {level+1} in {server_name}!"
+                    user_id,
+                    f"I'm so proud of you... You made it to level {level+1} in {server_name}!",
                 )
                 update_user_roles(server_id, user_id)
 

--- a/src/functions/frogeOfTheDay/main.py
+++ b/src/functions/frogeOfTheDay/main.py
@@ -5,7 +5,7 @@ import json
 import random
 from email.generator import Generator
 from io import BytesIO
-from typing import Any, List
+from typing import Any, List, Tuple
 
 import requests
 from google.cloud.firestore_v1.client import Client
@@ -17,7 +17,12 @@ from PIL import Image, ImageDraw, ImageFont
 IMAGE_FOLDER = "img/"
 
 
-def auto_scale_text_over_image(img: Image, text: str, shadow=(2, 2), shadow_color=(0, 0, 0)) -> Image:
+def auto_scale_text_over_image(
+    img: Image,
+    text: str,
+    shadow: Tuple[int, int] = (2, 2),
+    shadow_color: Tuple[int, int, int] = (0, 0, 0),
+) -> Image:
     """Resize image and add text over it."""
 
     width = 500
@@ -142,7 +147,7 @@ def publish_message_discord(channels: List[str], image_str: str = "") -> None:
         print(f"Published message to {topic_path}.")
 
 
-def publish_froge_of_the_day(_event, _context):
+def publish_froge_of_the_day(_event: Any, _context: Any) -> None:
     print("Start")
 
     channels = get_all_channels()

--- a/src/functions/hello/main.py
+++ b/src/functions/hello/main.py
@@ -1,10 +1,11 @@
 from typing import Any, Optional, Tuple
 
+import flask
 import functions_framework
 
 
 @functions_framework.http
-def hello(request) -> Tuple[str, int]:
+def hello(request: flask.Request) -> Tuple[str, int]:
     """This is a template function that show how to send back message."""
 
     request_json: Optional[Any] = request.get_json(silent=True)

--- a/src/functions/level/main.py
+++ b/src/functions/level/main.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import flask
 import functions_framework
@@ -63,7 +63,7 @@ def level(request: flask.Request) -> Tuple[str, int]:
     return ":|", 200
 
 
-def publish_generate_image(channel_id: str, payload) -> None:
+def publish_generate_image(channel_id: str, payload: Dict[str, Any]) -> None:
     """Publish image to generate_level_image."""
 
     project_id = "archy-f06ed"

--- a/src/main.py
+++ b/src/main.py
@@ -110,7 +110,7 @@ def send_message_to_channel(channel_id: str, message: str) -> None:
     publish_message(data, topic_id)
 
 
-def send_welcome_message(channel_id: str, username: str, avatar_url) -> None:
+def send_welcome_message(channel_id: str, username: str, avatar_url: str) -> None:
     """Publish message to generate_welcome_image."""
     topic_id = "generate_welcome_image"
     payload = {"username": username, "avatar_url": avatar_url}

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+    namespace_packages = True
+    explicit_package_bases = True
+    ignore_missing_imports = True
+    disallow_untyped_defs = True
+    disable_error_code = attr-defined, union-attr, name-defined, call-arg, type-arg, arg-type, assignment, operator, index, list-item, dict-item, typeddict-item, has-type, no-redef, func-returns-value, abstract, valid-newtype, exit-return, name-match, no-overload-impl, unused-coroutine, assert-type, syntax, misc, return-value

--- a/src/tests/functions/exp/test_exp.py
+++ b/src/tests/functions/exp/test_exp.py
@@ -10,7 +10,13 @@ from functions.exp.main import DATETIME_FORMAT, exp, send_message_to_user, updat
 
 MODULE_PATH = "functions.exp.main"
 
-GOOD_BODY = {"user_id": "123", "username": "Joe", "avatar_url": "url", "server_id": 123456789, "server_name": "Archy"}
+GOOD_BODY = {
+    "user_id": "123",
+    "username": "Joe",
+    "avatar_url": "url",
+    "server_id": 123456789,
+    "server_name": "Archy",
+}
 
 
 def get_good_db_value(param):  # pragma: no cover
@@ -152,7 +158,10 @@ def test_send_message_to_user(publisher_mock):
 
     send_message_to_user(user_id, message)
 
-    assert publisher_mock().method_calls[0].args == ("archy-f06ed", "private_message_discord")
+    assert publisher_mock().method_calls[0].args == (
+        "archy-f06ed",
+        "private_message_discord",
+    )
     assert publisher_mock().method_calls[1][0] == "publish"
     assert publisher_mock().method_calls[1][1][1] == encoded_data
 

--- a/src/tests/functions/level/test_level.py
+++ b/src/tests/functions/level/test_level.py
@@ -106,6 +106,9 @@ def test_publish_generate_image(publisher_mock):
 
     publish_generate_image(channel_id, payload)
 
-    assert publisher_mock().method_calls[0].args == ("archy-f06ed", "generate_level_image")
+    assert publisher_mock().method_calls[0].args == (
+        "archy-f06ed",
+        "generate_level_image",
+    )
     assert publisher_mock().method_calls[1][0] == "publish"
     assert publisher_mock().method_calls[1][1][1] == encoded_data

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 basepython = py39
-envlist = pytest, black, pylint, isort
+envlist = pytest, black, pylint, isort, mypy
 skipsdist = True
 whitelist_externals = env
 
@@ -9,6 +9,7 @@ deps =
     -rrequirements.txt
 file_and_folder_list = functions/ main.py tests/
 excluded_file_and_folder_list = env/
+mypy_folder_list = functions/ main.py
 
 [testenv:pytest]
 commands =
@@ -33,3 +34,10 @@ deps =
     isort
 commands =
     isort {[testenv]file_and_folder_list} --check
+
+[testenv:mypy]
+deps =
+    mypy
+    {[testenv]deps}
+commands =
+    mypy --install-types --non-interactive --show-error-codes {[testenv]mypy_folder_list}


### PR DESCRIPTION
Added mypy to tox testing configuration, it's currently set up to only look for function definitions that don't have types implemented, but as you'll see from the mypy.ini file, we've got a lot of error-codes that we can decide to implement of not.

Also added/fixed types for functions that were flagged as incorrect/incomplete, probably the biggest thing to look at to make sure it won't break anything.

[mypy documentation](https://mypy.readthedocs.io/en/stable/)