### PR TITLE
53 modifiy main node slash commands

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -574,6 +574,49 @@ async def help_(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="java")
+async def java(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "java"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,7 @@ from typing import Dict
 import firebase_admin
 import google.oauth2.id_token
 import requests
-from discord import DMChannel, Embed, Guild, Intents, Option, User
+from discord import DMChannel, Embed, Guild, Intents, Option
 from discord.abc import GuildChannel
 from discord.ext.commands import Bot, Context
 from discord.member import Member as member_type
@@ -260,7 +260,7 @@ async def treat_command(ctx: Context, command_name: str, data: Dict) -> None:
 
 
 @bot.slash_command(description="answers your question")
-async def answer(ctx: Context, question: str) -> None:
+async def answer(ctx: Context, question: Option(str, "your question", required=True)) -> None:
 
     server_id = str(ctx.guild.id)
     command_name = "answer"
@@ -279,104 +279,44 @@ async def answer(ctx: Context, question: str) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.slash_command(description="ban a user")
-async def ban(ctx: Context, user: Option(User, "user to ban", required=True)) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "ban"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user.id)],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="describe a user")
-async def describe(ctx: Context, user: Option(User, "user to describe", required=False)) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "kick"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user.id)],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="request a froge")
-async def froge(ctx: Context) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "froge"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="request a gif")
-async def gif(ctx: Context, query: Option(str, "query to search", required=False)) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "gif"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [query.split(" ")],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="go")
-async def go(ctx: Context) -> None:  # pylint: disable=invalid-name
-
-    server_id = str(ctx.guild.id)
-    command_name = "go"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
+# @bot.slash_command(description="request a gif")
+# async def gif(ctx: Context, query: Option(str, "query to search", required=False)) -> None:
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "gif"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+#        "params": [query.split(" ")],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
+#
+#
+# @bot.slash_command(description="go")
+# async def go(ctx: Context) -> None:  # pylint: disable=invalid-name
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "go"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+#        "params": [],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
 
 
 @bot.slash_command(description="hello! :)")
@@ -399,166 +339,166 @@ async def hello(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.slash_command(description="Get help about the bot")
-async def help_(ctx: Context) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "help"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="java")
-async def java(ctx: Context) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "java"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="js")
-async def js(ctx: Context) -> None:  # pylint: disable=invalid-name
-
-    server_id = str(ctx.guild.id)
-    command_name = "js"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="show the leaderboard")
-async def leaderboard(ctx: Context) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "leaderboard"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="show your level")
-async def level(ctx: Context) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "level"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="list warnings")
-async def listwarn(ctx: Context) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "listwarn"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="show merch info")
-async def merch(ctx: Context) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "merch"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-        "params": [],
-    }
-
-    await treat_command(ctx, command_name, data)
-
-
-@bot.slash_command(description="warn user")
-async def warn(
-    ctx: Context, user: Option(User, "user to warn", required=True), comment: Option(str, "comment", required=False)
-) -> None:
-
-    server_id = str(ctx.guild.id)
-    command_name = "warn"
-
-    data = {
-        "server_id": server_id,
-        "server_name": str(ctx.message.guild.name),
-        "user_id": str(ctx.author.id),
-        "username": str(ctx.author.name),
-        "channel_id": str(ctx.channel.id),
-        "message_id": str(ctx.message.id),
-        "mentions": [str(user.id)],
-        "params": [comment.split(" ")],
-    }
-
-    await treat_command(ctx, command_name, data)
+# @bot.slash_command(description="Get help about the bot")
+# async def help_(ctx: Context) -> None:
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "help"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+#        "params": [],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
+#
+#
+# @bot.slash_command(description="java")
+# async def java(ctx: Context) -> None:
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "java"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+#        "params": [],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
+#
+#
+# @bot.slash_command(description="js")
+# async def js(ctx: Context) -> None:  # pylint: disable=invalid-name
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "js"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+#        "params": [],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
+#
+#
+# @bot.slash_command(description="show the leaderboard")
+# async def leaderboard(ctx: Context) -> None:
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "leaderboard"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+#        "params": [],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
+#
+#
+# @bot.slash_command(description="show your level")
+# async def level(ctx: Context) -> None:
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "level"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+#        "params": [],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
+#
+#
+# @bot.slash_command(description="list warnings")
+# async def listwarn(ctx: Context) -> None:
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "listwarn"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+#        "params": [],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
+#
+#
+# @bot.slash_command(description="show merch info")
+# async def merch(ctx: Context) -> None:
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "merch"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+#        "params": [],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
+#
+#
+# @bot.slash_command(description="warn user")
+# async def warn(
+#    ctx: Context, user: Option(User, "user to warn", required=True), comment: Option(str, "comment", required=False)
+# ) -> None:
+#
+#    server_id = str(ctx.guild.id)
+#    command_name = "warn"
+#
+#    data = {
+#        "server_id": server_id,
+#        "server_name": str(ctx.message.guild.name),
+#        "user_id": str(ctx.author.id),
+#        "username": str(ctx.author.name),
+#        "channel_id": str(ctx.channel.id),
+#        "message_id": str(ctx.message.id),
+#        "mentions": [str(user.id)],
+#        "params": [comment.split(" ")],
+#    }
+#
+#    await treat_command(ctx, command_name, data)
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -703,6 +703,49 @@ async def leaderboard(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="level")
+async def level(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "level"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -488,7 +488,7 @@ async def go_(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
-@bot.SlashCommand.slash_command(description="hello")
+@bot.SlashCommand.slash_command(description="hello! :)")
 async def hello(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -531,7 +531,7 @@ async def hello(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
-@bot.SlashCommand.slash_command(description="help")
+@bot.SlashCommand.slash_command(description="Get help about the bot")
 async def help_(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -660,7 +660,7 @@ async def js_(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
-@bot.SlashCommand.slash_command(description="leaderboard")
+@bot.SlashCommand.slash_command(description="show the leaderboard")
 async def leaderboard(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -703,11 +703,54 @@ async def leaderboard(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
-@bot.SlashCommand.slash_command(description="level")
+@bot.SlashCommand.slash_command(description="show your level")
 async def level(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
     command_name = "level"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
+@bot.SlashCommand.slash_command(description="list warnings")
+async def listwarn(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "listwarn"
 
     if not is_active_command(server_id, command_name):
         await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")

--- a/src/main.py
+++ b/src/main.py
@@ -617,6 +617,49 @@ async def java(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="js")
+async def js_(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "js"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -488,6 +488,49 @@ async def go_(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="hello")
+async def hello(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "hello"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -229,6 +229,7 @@ async def on_message(message: message_type) -> None:
     if message.content == f"<@{bot.user.id}>":
         await ctx.send("> Who Dares Summon Me?")
 
+
 @bot.SlashCommand.slash_command(description="answers your question")
 async def answer(ctx: Context, question: str) -> None:
 
@@ -270,7 +271,7 @@ async def answer(ctx: Context, question: str) -> None:
                     color=0x04AA6D,
                 )
                 await ctx.send(embed=embed)
-            
+
 
 if __name__ == "__main__":
 

--- a/src/main.py
+++ b/src/main.py
@@ -316,6 +316,49 @@ async def ban(ctx: Context, user: Option(User, "user to ban", required=True)) ->
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="describe a user")
+async def describe(ctx: Context, user: Option(User, "user to describe", required=False)) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "kick"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user.id)],
+            "params": [str(user.id)],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -360,7 +360,7 @@ async def gif(ctx: Context, query: Option(str, "query to search", required=False
 
 
 @bot.slash_command(description="go")
-async def go_(ctx: Context) -> None:
+async def go(ctx: Context) -> None: # pylint: disable=invalid-name
 
     server_id = str(ctx.guild.id)
     command_name = "go"
@@ -400,7 +400,7 @@ async def hello(ctx: Context) -> None:
 
 
 @bot.slash_command(description="Get help about the bot")
-async def help_(ctx: Context) -> None:
+async def help(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
     command_name = "help"
@@ -440,7 +440,7 @@ async def java(ctx: Context) -> None:
 
 
 @bot.slash_command(description="js")
-async def js_(ctx: Context) -> None:
+async def js(ctx: Context) -> None: # pylint: disable=invalid-name
 
     server_id = str(ctx.guild.id)
     command_name = "js"

--- a/src/main.py
+++ b/src/main.py
@@ -359,6 +359,49 @@ async def describe(ctx: Context, user: Option(User, "user to describe", required
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="request a froge")
+async def froge(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "froge"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -531,6 +531,49 @@ async def hello(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="help")
+async def help_(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "help"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -789,6 +789,49 @@ async def listwarn(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="show merch info")
+async def merch(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "merch"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -259,7 +259,7 @@ async def treat_command(ctx: Context, command_name: str, data: Dict) -> None:
     increment_command_count(data["server_id"], command_name)
 
 
-@bot.SlashCommand.slash_command(description="answers your question")
+@bot.slash_command(description="answers your question")
 async def answer(ctx: Context, question: str) -> None:
 
     server_id = str(ctx.guild.id)
@@ -279,7 +279,7 @@ async def answer(ctx: Context, question: str) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="ban a user")
+@bot.slash_command(description="ban a user")
 async def ban(ctx: Context, user: Option(User, "user to ban", required=True)) -> None:
 
     server_id = str(ctx.guild.id)
@@ -299,7 +299,7 @@ async def ban(ctx: Context, user: Option(User, "user to ban", required=True)) ->
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="describe a user")
+@bot.slash_command(description="describe a user")
 async def describe(ctx: Context, user: Option(User, "user to describe", required=False)) -> None:
 
     server_id = str(ctx.guild.id)
@@ -319,7 +319,7 @@ async def describe(ctx: Context, user: Option(User, "user to describe", required
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="request a froge")
+@bot.slash_command(description="request a froge")
 async def froge(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -339,7 +339,7 @@ async def froge(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="request a gif")
+@bot.slash_command(description="request a gif")
 async def gif(ctx: Context, query: Option(str, "query to search", required=False)) -> None:
 
     server_id = str(ctx.guild.id)
@@ -359,7 +359,7 @@ async def gif(ctx: Context, query: Option(str, "query to search", required=False
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="go")
+@bot.slash_command(description="go")
 async def go_(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -379,7 +379,7 @@ async def go_(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="hello! :)")
+@bot.slash_command(description="hello! :)")
 async def hello(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -399,7 +399,7 @@ async def hello(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="Get help about the bot")
+@bot.slash_command(description="Get help about the bot")
 async def help_(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -419,7 +419,7 @@ async def help_(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="java")
+@bot.slash_command(description="java")
 async def java(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -439,7 +439,7 @@ async def java(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="js")
+@bot.slash_command(description="js")
 async def js_(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -459,7 +459,7 @@ async def js_(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="show the leaderboard")
+@bot.slash_command(description="show the leaderboard")
 async def leaderboard(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -479,7 +479,7 @@ async def leaderboard(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="show your level")
+@bot.slash_command(description="show your level")
 async def level(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -499,7 +499,7 @@ async def level(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="list warnings")
+@bot.slash_command(description="list warnings")
 async def listwarn(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -519,7 +519,7 @@ async def listwarn(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="show merch info")
+@bot.slash_command(description="show merch info")
 async def merch(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
@@ -539,7 +539,7 @@ async def merch(ctx: Context) -> None:
     await treat_command(ctx, command_name, data)
 
 
-@bot.SlashCommand.slash_command(description="warn user")
+@bot.slash_command(description="warn user")
 async def warn(
     ctx: Context, user: Option(User, "user to warn", required=True), comment: Option(str, "comment", required=False)
 ) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -360,7 +360,7 @@ async def gif(ctx: Context, query: Option(str, "query to search", required=False
 
 
 @bot.slash_command(description="go")
-async def go(ctx: Context) -> None: # pylint: disable=invalid-name
+async def go(ctx: Context) -> None:  # pylint: disable=invalid-name
 
     server_id = str(ctx.guild.id)
     command_name = "go"
@@ -400,7 +400,7 @@ async def hello(ctx: Context) -> None:
 
 
 @bot.slash_command(description="Get help about the bot")
-async def help(ctx: Context) -> None:
+async def help_(ctx: Context) -> None:
 
     server_id = str(ctx.guild.id)
     command_name = "help"
@@ -440,7 +440,7 @@ async def java(ctx: Context) -> None:
 
 
 @bot.slash_command(description="js")
-async def js(ctx: Context) -> None: # pylint: disable=invalid-name
+async def js(ctx: Context) -> None:  # pylint: disable=invalid-name
 
     server_id = str(ctx.guild.id)
     command_name = "js"

--- a/src/main.py
+++ b/src/main.py
@@ -832,6 +832,51 @@ async def merch(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="warn user")
+async def warn(
+    ctx: Context, user: Option(User, "user to warn", required=True), comment: Option(str, "comment", required=False)
+) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "warn"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user.id)],
+            "params": [comment.split(" ")],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -402,6 +402,49 @@ async def froge(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="request a gif")
+async def gif(ctx: Context, query: Option(str, "query to search", required=False)) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "gif"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [query.split(" ")],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -445,6 +445,49 @@ async def gif(ctx: Context, query: Option(str, "query to search", required=False
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="go")
+async def go_(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "go"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -660,6 +660,49 @@ async def js_(ctx: Context) -> None:
                 await ctx.send(embed=embed)
 
 
+@bot.SlashCommand.slash_command(description="leaderboard")
+async def leaderboard(ctx: Context) -> None:
+
+    server_id = str(ctx.guild.id)
+    command_name = "leaderboard"
+
+    if not is_active_command(server_id, command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+    else:
+        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+        data = {
+            "server_id": server_id,
+            "server_name": str(ctx.message.guild.name),
+            "user_id": str(ctx.author.id),
+            "username": str(ctx.author.name),
+            "channel_id": str(ctx.channel.id),
+            "message_id": str(ctx.message.id),
+            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+            "params": [],
+        }
+
+        response: Response = requests.post(
+            function_path,
+            headers={
+                "Authorization": f"Bearer {google_auth_token}",
+                "Content-Type": "application/json",
+            },
+            data=json.dumps(data),
+        )
+
+        if response.status_code == 200 and response.content:
+            if re.search("https://*", response.content.decode("utf-8")):
+                await ctx.send(response.content.decode("utf-8"))
+            else:
+                embed: Embed = Embed(
+                    description=response.content.decode("utf-8"),
+                    color=0x04AA6D,
+                )
+                await ctx.send(embed=embed)
+
+
 if __name__ == "__main__":
 
     cred = credentials.Certificate(KEY_FILE)

--- a/src/main.py
+++ b/src/main.py
@@ -230,6 +230,35 @@ async def on_message(message: message_type) -> None:
         await ctx.send("> Who Dares Summon Me?")
 
 
+async def treat_command(ctx: Context, command_name: str, data: Dict) -> None:
+    if not is_active_command(data["server_id"], command_name):
+        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
+        return
+
+    function_path = f"{FUNCTION_BASE_RUL}{command_name}"
+    google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+
+    response: Response = requests.post(
+        function_path,
+        headers={
+            "Authorization": f"Bearer {google_auth_token}",
+            "Content-Type": "application/json",
+        },
+        data=json.dumps(data),
+    )
+
+    if response.status_code == 200 and response.content:
+        if re.search("https://*", response.content.decode("utf-8")):
+            await ctx.send(response.content.decode("utf-8"))
+        else:
+            embed: Embed = Embed(
+                description=response.content.decode("utf-8"),
+                color=0x04AA6D,
+            )
+            await ctx.send(embed=embed)
+    increment_command_count(data["server_id"], command_name)
+
+
 @bot.SlashCommand.slash_command(description="answers your question")
 async def answer(ctx: Context, question: str) -> None:
 
@@ -241,36 +270,13 @@ async def answer(ctx: Context, question: str) -> None:
         "server_name": str(ctx.message.guild.name),
         "user_id": str(ctx.author.id),
         "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [question.split(" ")],
     }
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
 
-        data["channel_id"] = str(ctx.channel.id)
-        data["message_id"] = str(ctx.message.id)
-        data["mentions"] = [str(user_id) for user_id in ctx.message.raw_mentions]
-        data["params"] = [question]
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="ban a user")
@@ -279,41 +285,18 @@ async def ban(ctx: Context, user: Option(User, "user to ban", required=True)) ->
     server_id = str(ctx.guild.id)
     command_name = "ban"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user.id)],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user.id)],
-            "params": [str(user.id)],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="describe a user")
@@ -322,41 +305,18 @@ async def describe(ctx: Context, user: Option(User, "user to describe", required
     server_id = str(ctx.guild.id)
     command_name = "kick"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user.id)],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user.id)],
-            "params": [str(user.id)],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="request a froge")
@@ -365,41 +325,18 @@ async def froge(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "froge"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="request a gif")
@@ -408,41 +345,18 @@ async def gif(ctx: Context, query: Option(str, "query to search", required=False
     server_id = str(ctx.guild.id)
     command_name = "gif"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [query.split(" ")],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [query.split(" ")],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="go")
@@ -451,41 +365,18 @@ async def go_(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "go"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="hello! :)")
@@ -494,41 +385,18 @@ async def hello(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "hello"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="Get help about the bot")
@@ -537,41 +405,18 @@ async def help_(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "help"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="java")
@@ -580,41 +425,18 @@ async def java(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "java"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="js")
@@ -623,41 +445,18 @@ async def js_(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "js"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="show the leaderboard")
@@ -666,41 +465,18 @@ async def leaderboard(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "leaderboard"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="show your level")
@@ -709,41 +485,18 @@ async def level(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "level"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="list warnings")
@@ -752,41 +505,18 @@ async def listwarn(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "listwarn"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="show merch info")
@@ -795,41 +525,18 @@ async def merch(ctx: Context) -> None:
     server_id = str(ctx.guild.id)
     command_name = "merch"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
+        "params": [],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user_id) for user_id in ctx.message.raw_mentions],
-            "params": [],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 @bot.SlashCommand.slash_command(description="warn user")
@@ -840,41 +547,18 @@ async def warn(
     server_id = str(ctx.guild.id)
     command_name = "warn"
 
-    if not is_active_command(server_id, command_name):
-        await ctx.send("https://cdn.discordapp.com/emojis/823403768448155648.webp")
-    else:
-        function_path = f"{FUNCTION_BASE_RUL}{command_name}"
-        google_auth_token = google.oauth2.id_token.fetch_id_token(request, function_path)
+    data = {
+        "server_id": server_id,
+        "server_name": str(ctx.message.guild.name),
+        "user_id": str(ctx.author.id),
+        "username": str(ctx.author.name),
+        "channel_id": str(ctx.channel.id),
+        "message_id": str(ctx.message.id),
+        "mentions": [str(user.id)],
+        "params": [comment.split(" ")],
+    }
 
-        data = {
-            "server_id": server_id,
-            "server_name": str(ctx.message.guild.name),
-            "user_id": str(ctx.author.id),
-            "username": str(ctx.author.name),
-            "channel_id": str(ctx.channel.id),
-            "message_id": str(ctx.message.id),
-            "mentions": [str(user.id)],
-            "params": [comment.split(" ")],
-        }
-
-        response: Response = requests.post(
-            function_path,
-            headers={
-                "Authorization": f"Bearer {google_auth_token}",
-                "Content-Type": "application/json",
-            },
-            data=json.dumps(data),
-        )
-
-        if response.status_code == 200 and response.content:
-            if re.search("https://*", response.content.decode("utf-8")):
-                await ctx.send(response.content.decode("utf-8"))
-            else:
-                embed: Embed = Embed(
-                    description=response.content.decode("utf-8"),
-                    color=0x04AA6D,
-                )
-                await ctx.send(embed=embed)
+    await treat_command(ctx, command_name, data)
 
 
 if __name__ == "__main__":

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -3,5 +3,5 @@
     explicit_package_bases = True
     ignore_missing_imports = True
     disallow_untyped_defs = True
-    disable_error_code = attr-defined, union-attr, name-defined, call-arg, type-arg, arg-type, assignment, operator, index, list-item, dict-item, typeddict-item, has-type, no-redef, func-returns-value, abstract, valid-newtype, exit-return, name-match, no-overload-impl, unused-coroutine, assert-type, syntax, misc, return-value
+    disable_error_code = attr-defined, union-attr, name-defined, call-arg, type-arg, arg-type, assignment, operator, index, list-item, dict-item, typeddict-item, has-type, no-redef, func-returns-value, abstract, valid-newtype, exit-return, name-match, no-overload-impl, unused-coroutine, assert-type, syntax, misc, return-value, valid-type
     exclude = env

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -13,7 +13,6 @@ cloudevents==1.2.0
 coverage==6.4.1
 deprecation==2.1.0
 dill==0.3.4
-discord.py==2.0.1
 distlib==0.3.4
 filelock==3.7.0
 firebase-admin==4.5.1
@@ -59,6 +58,7 @@ protobuf==3.20.1
 py==1.11.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
+py-cord==2.2.2
 pylint==2.13.9
 pyparsing==3.0.9
 pytest==7.1.2


### PR DESCRIPTION
### Changes
- Ported bot over to Pycord 2.2.2
- Changed requirements.txt file to reflect that
- Added a treat_command function that takes the necessary context, command name, and data, and calls the cloud function
- Added a slash command function for every cloud function I have on my fork, nextjs not implemented
- Added a valid-type exception to mypy config because Pycord typing annotations don't play nice with mypy
- Kept the standard !command execution route for now


Needs to be tested to determine if we need to use pycord's Option type exclusively in the passing of parameters to slash commands, or if we can also use standard types such as str and int.