### PR TITLE
reframed !command execution route around the treat_command method

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -199,7 +199,7 @@ async def on_message(message: message_type) -> None:
         data["mentions"] = [str(user_id) for user_id in ctx.message.raw_mentions]
         data["params"] = message.content.split()[1:]
 
-        response = treat_command(ctx, command_name, data)
+        response = await treat_command(ctx, command_name, data)
 
         if re.search("https://*", response):
             await ctx.send(response)

--- a/src/main.py
+++ b/src/main.py
@@ -200,7 +200,7 @@ async def on_message(message: message_type) -> None:
         data["params"] = message.content.split()[1:]
 
         response = treat_command(ctx, command_name, data)
-        
+
         if re.search("https://*", response):
             await ctx.send(response)
         else:

--- a/src/mypy.ini
+++ b/src/mypy.ini
@@ -3,5 +3,5 @@
     explicit_package_bases = True
     ignore_missing_imports = True
     disallow_untyped_defs = True
-    disable_error_code = attr-defined, union-attr, name-defined, call-arg, type-arg, arg-type, assignment, operator, index, list-item, dict-item, typeddict-item, has-type, no-redef, func-returns-value, abstract, valid-newtype, exit-return, name-match, no-overload-impl, unused-coroutine, assert-type, syntax, misc, return-value, valid-type
+    disable_error_code = attr-defined, union-attr, name-defined, call-arg, type-arg, arg-type, assignment, operator, index, list-item, dict-item, typeddict-item, has-type, no-redef, func-returns-value, abstract, valid-newtype, exit-return, name-match, no-overload-impl, unused-coroutine, assert-type, syntax, misc, return-value, valid-type, call-overload
     exclude = env


### PR DESCRIPTION
Title says it all, I took the on_message event's treatment of the cloud functions and rerouted it through our general purpose treat_command function to minimize code repetition.