### PR TITLE
Feature/better golangci

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     steps:
-      - name: test
+      - name: Show working directory
         run: echo ${{ matrix.items }}
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -19,7 +19,7 @@ jobs:
           json_data=$(echo $clean_paths | jq -n -s '{ items: inputs }')
           echo "::set-output name=matrix::$(echo $json_data)"
   golangci:
-    name: lint
+    name: Golangci lint
     needs: matrix_prep
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -35,5 +35,5 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --config=./src/.golangci.yml
+          args: --config=../../.golangci.yml
           working-directory: ${{ matrix.items }}

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - id: set-matrix
         run: |
-          go_folder=$(find . -type f -name "*.go" -exec jq -n --arg path {} '$path' \;)
+          go_folder=$(find . -type f -name "*.go" -not -path "*/cmd/*.go" -exec jq -n --arg path {} '$path' \;)
           clean_paths=$( echo $go_folder | python -c "import sys;import re; tmp=sys.stdin.read(); print(re.sub('[^/]*.go\"', '\"', tmp))")
           json_data=$(echo $clean_paths | jq -n -s '{ items: inputs }')
           echo "::set-output name=matrix::$(echo $json_data)"

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -37,3 +37,14 @@ jobs:
           version: latest
           args: --config=../../.golangci.yml
           working-directory: ${{ matrix.items }}
+  all-golangci-passed:
+    if: always()
+    name: All golangci passed
+    runs-on: ubuntu-latest
+    needs:
+      - golangci
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -11,7 +11,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: set-matrix
         run: |
           go_folder=$(find . -type f -name "*.go" -not -path "*/cmd/*.go" -exec jq -n --arg path {} '$path' \;)
@@ -29,11 +29,11 @@ jobs:
         run: echo ${{ matrix.items }}
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.18
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout 3m0s
+          args: --config=./src/.golangci.yml
           working-directory: ${{ matrix.items }}

--- a/.github/workflows/python-tox.yaml
+++ b/.github/workflows/python-tox.yaml
@@ -3,7 +3,8 @@ on:
   - push
   - pull_request
 jobs:
-  build:
+  tox:
+    name: Tox
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/python-tox.yaml
+++ b/.github/workflows/python-tox.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
     defaults:
       run:
         working-directory: ./src

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,0 +1,32 @@
+# Options for analysis running.
+# Full config detail on https://golangci-lint.run/usage/configuration/
+run:
+  concurrency: 4
+  allow-parallel-runners: true
+
+go: "1.18"
+
+output:
+  format: colored-line-number
+  print-issued-lines: false
+  print-linter-name: false
+  uniq-by-line: false
+  path-prefix: ""
+  sort-results: false
+
+linters:
+  disable-all: true
+
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+  # Full list with `golangci-lint linters`
+  enable:
+    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
+    - gosimple # Linter for Go source code that specializes in simplifying code
+    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # Detects when assignments to existing variables are not used
+    - staticcheck # It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
+    - unused # Checks Go code for unused constants, variables, functions and types
+    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
+    - bodyclose # checks whether HTTP response body is closed successfully

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -21,6 +21,8 @@ linters:
   # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
   # Full list with `golangci-lint linters`
   enable:
+    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
+    - bodyclose # checks whether HTTP response body is closed successfully
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - gosimple # Linter for Go source code that specializes in simplifying code
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
@@ -28,5 +30,3 @@ linters:
     - staticcheck # It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
     - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - unused # Checks Go code for unused constants, variables, functions and types
-    - asciicheck # Simple linter to check that your code does not contain non-ASCII identifiers
-    - bodyclose # checks whether HTTP response body is closed successfully

--- a/src/functions/frogeOfTheDay/main.py
+++ b/src/functions/frogeOfTheDay/main.py
@@ -194,22 +194,19 @@ def get_quote() -> dict:
             "quote": "Click the little star on https://github.com/ArmandBriere/archy (Top right)",
             "author": "Hannibal119#3744",
         },
-        {
-            "quote": "If JS is the beta, than TS is the buggy release before the Day 1 Patch.",
-            "author": "EDav1123#7479"
-        },
-        {"quote": "Comment est votre blanquette?", "author": "BièreAuGibier Brigand#2022"},
+        {"quote": "If JS is the beta, than TS is the buggy release before the Day 1 Patch.", "author": "EDav1123#7479"},
+        {"quote": "Comment est votre blanquette ?", "author": "BièreAuGibier Brigand#2022"},
         {"quote": "J'aime me beurrer la biscotte.", "author": "BièreAuGibier Brigand#2022"},
         {"quote": "Où est Heinrich Von Zimmel ?", "author": "BièreAuGibier Brigand#2022"},
         {
-            "quote": "Une dictature c’est quand les gens sont communistes, déjà. Ils ont froid, "
+            "quote": "Une dictature c'est quand les gens sont communistes, déjà. Ils ont froid, "
             + "des chapeaux gris et des chaussures à fermeture éclair.",
-            "author": "BièreAuGibier Brigand#2022"
+            "author": "BièreAuGibier Brigand#2022",
         },
         {
             "quote": "On va toujours trop loin pour les gens qui ne vont nulle part.",
-            "author": "BièreAuGibier Brigand#2022"
-        }
+            "author": "BièreAuGibier Brigand#2022",
+        },
     ]
 
     return random.choice(quotes)

--- a/src/functions/listwarn/listWarn.go
+++ b/src/functions/listwarn/listWarn.go
@@ -96,7 +96,7 @@ func generateWarnList(serverId string) string {
 		}
 
 		data.WriteString("**")
-		data.WriteString(warn.Timestamp.Format("2006-02-01"))
+		data.WriteString(warn.Timestamp.Format("2006-01-02"))
 		data.WriteString("**\n")
 		data.WriteString("User: <@")
 		data.WriteString(warn.UserId)

--- a/src/functions/stm/stm.go
+++ b/src/functions/stm/stm.go
@@ -127,6 +127,7 @@ func fetchStmStatus() StmStatus {
 		log.Fatalln(err)
 	}
 
+	resp.Body.Close()
 	return stmStatus
 }
 

--- a/src/golint.sh
+++ b/src/golint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-find . -name "*.go" -not -path "*/cmd/*.go" -execdir pwd \; -execdir $(go env GOPATH)/bin/golangci-lint run --go=1.18 \;
+find . -name "*.go" -not -path "*/cmd/*.go" -execdir pwd \; -execdir /usr/bin/golangci-lint run --go=1.18 --config=../../.golangci.yml \;

--- a/src/golint.sh
+++ b/src/golint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-find . -name "*.go" -execdir pwd \; -execdir $(go env GOPATH)/bin/golangci-lint run \;
+find . -name "*.go" -not -path "*/cmd/*.go" -execdir pwd \; -execdir $(go env GOPATH)/bin/golangci-lint run --go=1.18 \;


### PR DESCRIPTION
- Update golangci to not check cmd folders
- Update golangci config
  - We can select linters now
- Fix go version to 1.18 in CI to fix compatibility issues in CI
- Add `re-actors/alls-green` for force all CI validation before merge
- Edit branch security to force all CI validation before merge
- Remove Tox run in 3.9
- Fix Python and Go code to pass lint