### PR TITLE
Update CI to use the new GITHUB_OUTPUT env var

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
           go_folder=$(find . -type f -name "*.go" -not -path "*/cmd/*.go" -exec jq -n --arg path {} '$path' \;)
           clean_paths=$( echo $go_folder | python -c "import sys;import re; tmp=sys.stdin.read(); print(re.sub('[^/]*.go\"', '\"', tmp))")
           json_data=$(echo $clean_paths | jq -n -s '{ items: inputs }')
-          echo "matrix::$(echo $json_data)" >> $GITHUB_OUTPUT
+          echo "matrix=$(echo $json_data)" >> $GITHUB_OUTPUT
 
   golangci:
     name: Golangci lint

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
           go_folder=$(find . -type f -name "*.go" -not -path "*/cmd/*.go" -exec jq -n --arg path {} '$path' \;)
           clean_paths=$( echo $go_folder | python -c "import sys;import re; tmp=sys.stdin.read(); print(re.sub('[^/]*.go\"', '\"', tmp))")
           json_data=$(echo $clean_paths | jq -n -s '{ items: inputs }')
-          echo "name=matrix::$(echo $json_data)" >> $GITHUB_OUTPUT
+          echo "matrix::$(echo $json_data)" >> $GITHUB_OUTPUT
 
   golangci:
     name: Golangci lint

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,8 @@ jobs:
           go_folder=$(find . -type f -name "*.go" -not -path "*/cmd/*.go" -exec jq -n --arg path {} '$path' \;)
           clean_paths=$( echo $go_folder | python -c "import sys;import re; tmp=sys.stdin.read(); print(re.sub('[^/]*.go\"', '\"', tmp))")
           json_data=$(echo $clean_paths | jq -n -s '{ items: inputs }')
-          echo "::set-output name=matrix::$(echo $json_data)"
+          echo "name=matrix::$(echo $json_data)" >> $GITHUB_OUTPUT
+
   golangci:
     name: Golangci lint
     needs: matrix_prep

--- a/.github/workflows/terraform-plan-dev.yaml
+++ b/.github/workflows/terraform-plan-dev.yaml
@@ -85,7 +85,7 @@ jobs:
 
             </details>
 
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;
 
             // 3. If we have a comment, update it, otherwise create a new one
             if (botComment) {

--- a/.github/workflows/terraform-plan-prod.yaml
+++ b/.github/workflows/terraform-plan-prod.yaml
@@ -85,7 +85,7 @@ jobs:
 
             </details>
 
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;
 
             // 3. If we have a comment, update it, otherwise create a new one
             if (botComment) {


### PR DESCRIPTION
- `::set-output` is deprecated
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Remove empty working dir display in summary