### PR TITLE
added a command for enabling/disabling a specific command

### DIFF
--- a/src/functions/enable_command/main.py
+++ b/src/functions/enable_command/main.py
@@ -1,0 +1,42 @@
+import json
+import os
+from typing import Any, Optional, Tuple
+
+import firebase_admin
+import flask
+import functions_framework
+from firebase_admin import firestore
+from google.cloud.firestore_v1.base_document import DocumentSnapshot
+from google.cloud.firestore_v1.collection import CollectionReference
+from google.cloud.firestore_v1.document import DocumentReference
+
+GOOGLE_APPLICATION_CREDENTIALS = json.loads(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"))
+
+
+@functions_framework.http
+def enable_command(request: flask.Request) -> Tuple[str, int]:
+
+    request_json: Optional[Any] = request.get_json(silent=True)
+
+    if request_json:
+        command = request_json.get("command", None)
+        enable = request_json.get("enable", None)
+        if not command and not enable:
+            return "Invalid request", 400
+    else:
+        return "Invalid request", 400
+
+    certificate = firebase_admin.credentials.Certificate(GOOGLE_APPLICATION_CREDENTIALS)
+    firebase_admin.initialize_app(certificate)
+
+    database = firestore.client()
+
+    server_list_collection: CollectionReference = database.collection("server_list")
+    for server in server_list_collection.stream():
+        server: DocumentSnapshot
+        server_id: str = server.id
+        server: DocumentReference = server_list_collection.document(server_id)
+        functions_collection: CollectionReference = server.collection("functions")
+        functions_collection.document(command).set({"enable": enable})
+
+    return f"Command {'enabled' if enable else 'disabled'}", 200

--- a/src/main.py
+++ b/src/main.py
@@ -440,6 +440,25 @@ async def http(ctx: Context, query: Option(int, "HTTP code", required=True)) -> 
     await interaction.edit_original_response(content=message)
 
 
+@bot.slash_command(description="enable or disable a command", guild_ids=[964701887540645908])
+async def enable_command(
+    ctx: Context,
+    command: Option(str, "command to enable or disable", required=True),
+    enable: Option(bool, "should the command be enabled?", required=True),
+) -> None:
+
+    command_name = "enable_command"
+
+    data = {"server_id": str(ctx.guild.id), "command": command, "enable": enable}
+
+    if not ctx.author.roles.find("name", "contributors"):
+        await ctx.respond("You are not a contributor")
+    else:
+        interaction = await ctx.respond(LOADING_MESSAGE)
+        response = await treat_command(ctx, command_name, data)
+        await interaction.edit_original_response(content=response)
+
+
 if __name__ == "__main__":
 
     # Firebase env var instead of file


### PR DESCRIPTION
Adds the ability to set whether or not a command is enabled across all servers.

The command can only be called from within the development server
The command can only be called by users that have the contributor role

The command takes a command name and a boolean, if the boolean is set to true, the "command name" command will be active on all servers, if the boolean is false the command will be disabled on all servers.