### PR TITLE
fix: temporarily trim stm status text header if matching lucien lalli…

### DIFF
--- a/src/functions/stm/stm.go
+++ b/src/functions/stm/stm.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -175,6 +176,8 @@ func updateStatus(newStmStatus StmStatus, lineIndex int, wg *sync.WaitGroup) {
 			panic(err)
 		}
 
+		// Temporarily remove stm status header about Lucien L'allier April 2024 until they fix their API
+		newStmStatusText = trimStatusHeader(newStmStatusText)
 		if newStmStatusText != oldStatusText {
 			_, err = stmStatusRef.Update(firestoreCtx, []firestore.Update{
 				{
@@ -262,4 +265,17 @@ func publishChannelMessage(channels []string, message string) {
 
 		log.Println("Message send to topic, messageId: " + messageId)
 	}
+}
+
+func trimStatusHeader(statusText string) string {
+	r, err := regexp.Compile("^(Station Lucien-L'Allier : À partir du 1er avril 2024).*</a>(\r\n|\r|\n)")
+	if err != nil {
+		panic(err)
+	}
+	match := r.MatchString(statusText)
+	if match {
+		// remove first line
+		statusText = statusText[strings.Index(statusText, "\n")+1:]
+	}
+	return statusText
 }


### PR DESCRIPTION
Actual behavior: 

```
STM -  Orange line
Station Lucien-L'Allier : À partir du 1er avril 2024, aucun train exo ne desservira la gare Lucien-L'Allier. <a class="external" href="https://exo.quebec/fr/actualites/realisations/gare-lucien-lallier?gad_source=1?utm_campaign=mip&utm_source=exogarell&utm_medium=horairesstm" target="_blank"> Pour en savoir plus</a>
Service normal du métro

🎵 too doo doo 🎵
```

Desired behavior:

```
STM -  Orange line
Service normal du métro

🎵 too doo doo 🎵
```